### PR TITLE
Make GDB debugger more user scriptable

### DIFF
--- a/.dockerfile_dbg
+++ b/.dockerfile_dbg
@@ -37,3 +37,4 @@ RUN sudo chown $USER:$USER .gdbinit debugger.sh && \
     echo "export PATH=/home/$USER/.local/bin/:${PATH}" >> /home/$USER/.zshrc
 
 WORKDIR /io
+COPY io/scripts/gdb_script .

--- a/config.ini
+++ b/config.ini
@@ -67,6 +67,9 @@ kpti = yes
 tag = like_debugger
 # Name of the dockerfile 
 dockerfile = .dockerfile_dbg
+# Execute additional GDB commands from this file 
+# DO NOT EDIT PATH
+gdb_script = io/scripts/gdb_script
 
 [kernel_general]
 # Folder name the kernel source is unpacked into

--- a/io/scripts/debugger.sh
+++ b/io/scripts/debugger.sh
@@ -63,5 +63,6 @@ gdb-multiarch -q "$VMLINUX" -iex "set architecture $ARCH" -ex "gef-remote --qemu
     -ex "continue" \
     -ex "lx-symbols" \
     -ex "macro define offsetof(_type, _memb) ((long)(&((_type *)0)->_memb))" \
-    -ex "macro define containerof(_ptr, _type, _memb) ((_type *)((void *)(_ptr) - offsetof(_type, _memb)))"
+    -ex "macro define containerof(_ptr, _type, _memb) ((_type *)((void *)(_ptr) - offsetof(_type, _memb)))" \
+    -x gdb_script
 

--- a/io/scripts/gdb_script
+++ b/io/scripts/gdb_script
@@ -1,0 +1,2 @@
+# Feel free to specify your custom GDB commands in here
+# Note: This will require rebuilding the debugger container


### PR DESCRIPTION
This is a quick first fix for #29 that is far from perfect. Having to rebuild the debugger image is currently a pain so a next step would be to implement #25 in a way that it allows rebuilding the container on the fly. As we're just manipulating a single file here a rebuild should not disturb the experience much