### PR TITLE
Partial runs

### DIFF
--- a/src/linux_kernel_dl.py
+++ b/src/linux_kernel_dl.py
@@ -32,7 +32,7 @@ class KernelDownloader:
         elif self.commit:
             return self.commit
         else:
-            self._resolve_latest()
+            return self._resolve_latest()
 
     def _resolve_latest(self) -> str:
         commit_re = rb"commit\/\?id=[0-9a-z]*"
@@ -62,7 +62,7 @@ class KernelDownloader:
             self.mmp_uri = self.mmp_uri.replace("KPATCH", patch)
             return self.mmp_uri
         else:
-            return "{self.snap_uri}{self.choice}.tar.gz"
+            return f"{self.snap_uri}{self.choice}.tar.gz"
 
     def is_present(self) -> bool:
         if Path(self.archive).exists():

--- a/src/linux_kernel_dl.py
+++ b/src/linux_kernel_dl.py
@@ -66,7 +66,7 @@ class KernelDownloader:
 
     def is_present(self) -> bool:
         if Path(self.archive).exists():
-            logger.debug("Kernel archive already exists locally. Skipping download...")
+            logger.info("Kernel archive already exists locally. Skipping download...")
             return True
         else:
             return False

--- a/start_kgdb.py
+++ b/start_kgdb.py
@@ -49,21 +49,35 @@ def kill_session() -> None:
     exit(0)
 
 
-def stage4(skip: bool, **kwargs) -> None:
+def stage5(skip: bool, ctf: bool, generic_args: dict, dbge_args: dict, dbg_args: dict) -> None:
+    if not ctf:
+        kunpacker = stage4(skip, **generic_args)
+    else:
+        kunpacker = {}
+    tmux("splitw -h -p 50")
+    tmux("selectp -t 0")
+    tmux("splitw -v -p 50")
+    tmux("selectp -t 0")
+    Debuggee(**dbge_args | kunpacker).run()
+    tmux("selectp -t 0")
+    Debugger(**dbg_args | kunpacker).run()
+    tmux("selectp -t 0")
+
+
+def stage4(skip: bool, **kwargs) -> dict[str, str]:
     if not skip:
         kunpacker = stage3(skip, **kwargs)
         RootFSBuilder(**kwargs | kunpacker).run()
+        return kunpacker
     else:
         RootFSBuilder(**kwargs, kroot="foobar").run()
-    # {'kroot': PosixPath('kernel_root/linux-5.10.77_x86_64'), 'status_code': 0, 'assume_dirty': True}
-    logger.info(kunpacker)
-    logger.info(kwargs)
+        return {}
 
 
 def stage3(skip: bool, **kwargs) -> dict:
     kunpacker = stage2(**kwargs)
     if not kunpacker["status_code"] and not skip:
-        KernelBuilder(kwargs | kunpacker).run()
+        KernelBuilder(**kwargs | kunpacker).run()
     return kunpacker
 
 
@@ -72,11 +86,11 @@ def stage2(**kwargs) -> dict:
     return KernelUnpacker(kaname, **kwargs).run()
 
 
-def stage1() -> str:
+def stage1() -> Path:
     return KernelDownloader().run()
 
 
-def main():
+def parse_cli() -> argparse.Namespace:
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(
         "--ctf",
@@ -102,7 +116,11 @@ def main():
     """
         ),
     )
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def main():
+    args = parse_cli()
     log_level = set_log_level(args.verbose)
 
     if args.kill:
@@ -116,7 +134,6 @@ def main():
     tmux("selectp -t 0")
     tmux('rename-session "LIKE-DBG"')
     tmux('rename-window "LIKE-DBG"')
-    kunpacker = {}
     generic_args = {"skip_prompts": True if args.yes else False, "ctf_ctx": True if args.ctf else False, "log_level": log_level}
     dbge_args = {} | generic_args
     dbg_args = {} | generic_args
@@ -128,7 +145,7 @@ def main():
         elif args.partial == 2:
             stage2(**generic_args)
         elif args.partial == 3:
-            stage3(**generic_args)
+            stage3(skip=False, **generic_args)
         else:
             stage4(skip=True, **generic_args)
         exit(0)
@@ -145,18 +162,12 @@ def main():
             exit(-1)
         dbge_args = generic_args | {"ctf_kernel": ctf_kernel, "ctf_fs": ctf_fs}
         dbg_args = {k: v for k, v in dbge_args.items() if k != "ctf_fs"}
+        skip = True
     else:
         logger.debug("Executing in non-CTF context")
-        stage4(**generic_args, skip=False)
+        skip = False
 
-    tmux("splitw -h -p 50")
-    tmux("selectp -t 0")
-    tmux("splitw -v -p 50")
-    tmux("selectp -t 0")
-    Debuggee(**dbge_args | kunpacker).run()
-    tmux("selectp -t 0")
-    Debugger(**dbg_args | kunpacker).run()
-    tmux("selectp -t 0")
+    stage5(skip, generic_args["ctf_ctx"], generic_args, dbge_args, dbg_args)
 
 
 if __name__ == "__main__":

--- a/start_kgdb.py
+++ b/start_kgdb.py
@@ -58,7 +58,7 @@ def stage4(skip: bool, **kwargs) -> None:
 def stage3(skip: bool, **kwargs) -> dict:
     kunpacker = stage2(kwargs)
     if not kunpacker["status_code"] and not skip:
-        KernelBuilder(**kwargs | kunpacker).run()
+        KernelBuilder(kwargs | kunpacker).run()
     return kunpacker
 
 


### PR DESCRIPTION
This PR introduces an option to do partial runs.
This eases development as well as allows exploring the framework easier as one does not have to commit to all the steps.
Therefore, the new `[-p | --partial]` flag introduces these capabilities.