### PR TITLE
WIP: support pwndbg as a GDB extension

### DIFF
--- a/.dockerfile_dbg
+++ b/.dockerfile_dbg
@@ -34,9 +34,15 @@ ENV LC_ALL=en_US.UTF-8
 
 USER $USER
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN wget -q -O- https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | bash -s - && \
+RUN set -e && \
+    wget -q -O- https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | bash -s - > /dev/null && \
+    git clone --depth=1 https://github.com/pwndbg/pwndbg && \
+    pushd pwndbg > /dev/null && \
+    chmod +x setup.sh && \
+    echo 'y' | ./setup.sh && \
+    popd > /dev/null && \
     wget -q -O ~/.gdbinit-gef.py -q https://gef.blah.cat/dev && \
-    echo source ~/.gdbinit-gef.py >> ~/.gdbinit && \
+    echo "source ~/.gdbinit-gef.py" >> ~/.gdbinit && \
     wget -q -O- https://github.com/hugsy/gef/raw/dev/scripts/gef-extras.sh | bash -s - -b dev && \
     echo "export PATH=/home/$USER/.local/bin/:${PATH}" >> /home/$USER/.zshrc
 

--- a/.dockerfile_dbge
+++ b/.dockerfile_dbge
@@ -17,3 +17,4 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /io
+HEALTHCHECK --interval=1s --timeout=2s --retries=3 --start-period=2s CMD ps aux | grep "qemu-system" | grep -v grep || exit 1

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ On the upside, despite its early stages, a couple of useful features are already
   * Powered by [QEMU](https://github.com/qemu/qemu)
   * Customization of QEMU runtime options from within the `configs/*.ini` files.
 * Debugger:
-  * Powered by [GDB (multiarch)](https://sourceware.org/gdb/) + [GEF](https://github.com/hugsy/gef) and [GEF-extras](https://github.com/hugsy/gef-extras)
+  * Powered by [GDB (multiarch)](https://sourceware.org/gdb/) with either
+    * [GEF](https://github.com/hugsy/gef) and [GEF-extras](https://github.com/hugsy/gef-extras), or
+    * [pwndbg](https://github.com/pwndbg/pwndbg)
   * Allow users to specify GDB script in `io/scripts/gdb_script` to allow a scenario-tailored debugging experience
 
 ## Requirements
@@ -118,7 +120,7 @@ python3 -m pip install -r requirements.txt
 ./start_kgdb.py
 ```
 
-### Extended Usage:
+### Extended Usage
 
 ```sh
 # If you want to try a CTF challenge where you were given a (compressed) Linux Image and a root filesystem try:

--- a/configs/user.ini
+++ b/configs/user.ini
@@ -1,6 +1,6 @@
 [general]
 # Architecture which is targeted
-# Currently only x86_64 and arm64 is supported
+# arch ∈ [x86_64, arm64]
 arch = x86_64
 # Allows creating a descriptive tag so that the same kernel versions can be unpacked into different folders, to e.g.: reflect different compilation methods
 kernel_tag = 
@@ -10,7 +10,7 @@ kernel_tag =
 # Pull a specific MAJOR.MINOR.PATCH version of the kernel, e.g. 5.15.67
 mmp = 
 # We can checkout a specific release tag like 5.15-rc2
-tag = 
+tag =
 # Alternatively, we can grab a specific commit
 # IFF mmp, tag, and commit are unset, we will automatically grab the latest available commit
 commit = 
@@ -93,3 +93,6 @@ panic = halt
 [debugger]
 # Force to rebuild the container
 force_rebuild = no
+# Set GDB extension
+# ext ∈ [gef, pwndbg]
+ext = gef

--- a/io/scripts/debugger.sh
+++ b/io/scripts/debugger.sh
@@ -5,74 +5,107 @@ VMLINUX=""
 ARCH=""
 CTF_CTX=0
 PATH_GDB_SCRIPT=""
+EXT="gef"
+USER="user"
 
 while (("$#")); do
-    case "$1" in
-        -a | --arch)
-            # Sets the architecture as expected in GDB
-            ARCH=$2
-            shift 2
-            ;;
-        -p | --project)
-            # Sets the kernel root dir where vmlinux is located
-            PROJECT_DIR=$2
-            VMLINUX=$PROJECT_DIR/vmlinux
-            shift 2
-            ;;
-        -c | --ctf)
-            # Sets the CTX context, as we do not need to fix the symlink if we are in a CTF context
-            CTF_CTX=$2
-            shift 2
-            ;;
-        -g | --gdb_script)
-            # Sets the location of the user defined GDB script
-            PATH_GDB_SCRIPT=$2
-            shift 2
-            ;;
-        -*)
-            echo "Error: Unknown option: $1" >&2
-            exit 1
-            ;;
-        *) # No more options
-            break
-            ;;
-    esac
+	case "$1" in
+	-a | --arch)
+		# Sets the architecture as expected in GDB
+		ARCH=$2
+		shift 2
+		;;
+	-p | --project)
+		# Sets the kernel root dir where vmlinux is located
+		PROJECT_DIR=$2
+		VMLINUX=$PROJECT_DIR/vmlinux
+		shift 2
+		;;
+	-c | --ctf)
+		# Sets the CTX context, as we do not need to fix the symlink if we are in a CTF context
+		CTF_CTX=$2
+		shift 2
+		;;
+	-g | --gdb_script)
+		# Sets the location of the user defined GDB script
+		PATH_GDB_SCRIPT=$2
+		shift 2
+		;;
+	-e | --extension)
+		# Sets whether we want to use GDB-GEF or PWNDBG
+		EXT=$2
+		shift 2
+		;;
+	-u | --user)
+		# Sets the docker user
+		USER=$2
+		shift 2
+		;;
+	-*)
+		echo "Error: Unknown option: $1" >&2
+		exit 1
+		;;
+	*) # No more options
+		break
+		;;
+	esac
 done
 
 if [ -z "$PROJECT_DIR" ] || [ -z "$VMLINUX" ] || [ -z "$ARCH" ] || [ -z "$PATH_GDB_SCRIPT" ]; then
-    echo "[!] Not all required arguments were set"
-    exit 255
+	echo "[!] Not all required arguments were set"
+	exit 255
 fi
 
-pushd "$HOME" > /dev/null || exit
-echo "add-auto-load-safe-path $PROJECT_DIR" >> .gdbinit
-popd > /dev/null || exit
+pushd "$HOME" >/dev/null || exit
+echo "add-auto-load-safe-path $PROJECT_DIR" >>.gdbinit
+if [ "$EXT" == "gef" ]; then
+	sed -ir "s/source.*pwndbg.*/# &/" .gdbinit
+else
+	sed -ir "s/source.*gef.*/# &/" .gdbinit
+fi
+popd >/dev/null || exit
 
 if [ "$CTF_CTX" -ne 1 ]; then
-    sudo rm -f vmlinux-gdb.py
-    sudo ln -sd scripts/gdb/vmlinux-gdb.py .
+	sudo rm -f vmlinux-gdb.py
+	sudo ln -sd scripts/gdb/vmlinux-gdb.py .
 fi
 
 # Handle GDB naming sceme
 case "$ARCH" in
-    arm64)
-        ARCH=aarch64
-        ;;
-    arm)
-        ARCH=armv7
-        ;;
-    x86_64)
-        ARCH=i386:x86-64:intel
-        ;;
-    *) ;;
+arm64)
+	ARCH=aarch64
+	;;
+arm)
+	ARCH=armv7
+	;;
+x86_64)
+	ARCH=i386:x86-64:intel
+	;;
+*) ;;
 
 esac
 
-gdb-multiarch -q "$VMLINUX" -iex "set architecture $ARCH" -ex "gef-remote --qemu-user --qemu-binary $VMLINUX localhost 1234" \
-    -ex "add-symbol-file $VMLINUX" \
-    -ex "break start_kernel" \
-    -ex "continue" \
-    -ex "lx-symbols" \
-    -ex "macro define offsetof(_type, _memb) ((long)(&((_type *)0)->_memb))" \
-    -ex "macro define containerof(_ptr, _type, _memb) ((_type *)((void *)(_ptr) - offsetof(_type, _memb)))" \
-    -x "$PATH_GDB_SCRIPT"
+GDB="gdb-multiarch -q \"$VMLINUX\" -iex \"set architecture $ARCH\" \
+    -ex \"add-symbol-file $VMLINUX\""
+
+if [ "$EXT" == "gef" ]; then
+	GDB="${GDB} -ex \"gef-remote --qemu-user --qemu-binary $VMLINUX localhost 1234\""
+else
+	GDB="${GDB} -ex \"target remote :1234\" -ex \"set kernel-vmmap page-tables\""
+fi
+
+GDB="${GDB} -ex \"break start_kernel\" \
+    -ex \"continue\" \
+    -ex \"lx-symbols\" \
+    -ex \"macro define offsetof(_type, _memb) ((long)(&((_type *)0)->_memb))\" \
+    -ex \"macro define containerof(_ptr, _type, _memb) ((_type *)((void *)(_ptr) - offsetof(_type, _memb)))\" \
+    -x \"$PATH_GDB_SCRIPT\""
+
+if [ "$EXT" == "gef" ]; then
+	eval "$GDB"
+else
+	sudo cp "/home/$USER/.gdbinit" "/root/"
+	echo "add-auto-load-safe-path /home/$USER/.gdbinit" | sudo tee -a "/root/.gdbinit"
+	GDB="sudo su -c '${GDB}'"
+	eval "$GDB"
+fi

--- a/kb/README.md
+++ b/kb/README.md
@@ -46,11 +46,15 @@ Section to dump good write-ups that either feature an actual exploit, a new tech
 
 ### Public exploits
 
+* [The exploit recon 'msg_msg' and its mitigation in VED](https://hardenedvault.net/blog/2022-11-13-msg_msg-recon-mitigation-ved/)
 * [[CVE-2022-101(5|6)] How The Tables Have Turned: An analysis of two new Linux vulnerabilities in nf_tables](https://blog.dbouman.nl/2022/04/02/How-The-Tables-Have-Turned-CVE-2022-1015-1016/)
 * [[CVE-2022-32250] SETTLERS OF NETLINK: Exploiting a limited UAF in nf_tables](https://research.nccgroup.com/2022/09/01/settlers-of-netlink-exploiting-a-limited-uaf-in-nf_tables-cve-2022-32250/)
 * [[CVE-2022-2586] N-day exploit for CVE-2022-2586: Linux kernel nft_object UAF](https://www.openwall.com/lists/oss-security/2022/08/29/5)
 * [[CVE-2022-1786] A Journey To The Dawn](https://blog.kylebot.net/2022/10/16/CVE-2022-1786/)
 * [Writing a Linux Kernel Remote in 2022](https://blog.immunityinc.com/p/writing-a-linux-kernel-remote-in-2022/)
+* [CVE-2021-22555: Turning \x00\x00 into 10000$](https://google.github.io/security-research/pocs/linux/cve-2021-22555/writeup.html#escaping-the-container-and-popping-a-root-shell)
+* [A deep root in Linux's filesystem layer (CVE-2021-33909)](https://www.qualys.com/2021/07/20/cve-2021-33909/sequoia-local-privilege-escalation-linux.txt)
+* [Exploiting CVE-2021-43267](https://haxx.in/posts/pwning-tipc/)
 * [Four Bytes of Power: Exploiting CVE-2021-26708 in the Linux kernel](https://a13xp0p0v.github.io/2021/02/09/CVE-2021-26708.html)
   * [Improving the exploit for CVE-2021-26708 in the Linux kernel to bypass LKRG](https://a13xp0p0v.github.io/2021/08/25/lkrg-bypass.html)
 * [Put an io_uring on it: Exploiting the Linux Kernel](https://www.graplsecurity.com/post/iou-ring-exploiting-the-linux-kernel)
@@ -58,6 +62,7 @@ Section to dump good write-ups that either feature an actual exploit, a new tech
 * [[CVE-2021-42008] Exploiting A 16-Year-Old Vulnerability In The Linux 6pack Driver](https://syst3mfailure.io/sixpack-slab-out-of-bounds)
 * [Anatomy of an Exploit: RCE with CVE-2020-1350 SIGRed](https://www.graplsecurity.com/post/anatomy-of-an-exploit-rce-with-cve-2020-1350-sigred)
 * [[CVE-2019-15666] Ubuntu / CentOS / RHEL Linux Kernel 4.4 - 4.18 privilege escalation](https://duasynt.com/blog/ubuntu-centos-redhat-privesc)
+* [CVE-2017-11176: A step-by-step Linux Kernel exploitation (part 1/4)](https://blog.lexfo.fr/cve-2017-11176-linux-kernel-exploitation-part1.html)
 
 ### Interesting CTF exploits
 

--- a/src/debuggee.py
+++ b/src/debuggee.py
@@ -71,7 +71,7 @@ class Debuggee(DockerRunner):
         # FIXME: Ugly hack to make us allow getting the container object.
         time.sleep(1)
         self.container = self.client.containers.get(f"{self.tag}")
-        self.wait_for_container(running=True)
+        self.wait_for_container()
 
     def run_container(self):
         mount_point = self.ctf_mount if self.ctf else Path.cwd()

--- a/src/debuggee.py
+++ b/src/debuggee.py
@@ -65,10 +65,18 @@ class Debuggee(DockerRunner):
         if self.smap:
             self.cmd += ",+smap"
 
+    def _ensure_container_is_up(self):
+        import time
+
+        # FIXME: Ugly hack to make us allow getting the container object.
+        time.sleep(1)
+        self.container = self.client.containers.get(f"{self.tag}")
+        self.wait_for_container(running=True)
+
     def run_container(self):
         mount_point = self.ctf_mount if self.ctf else Path.cwd()
         kernel = Path(self.docker_mnt) / self.kernel.name if self.ctf else self.kernel
-        dcmd = f'docker run -it --rm -v {mount_point}:/io --net="host" like_debuggee '
+        dcmd = f'docker run --name {self.tag} -it --rm -v {mount_point}:/io --net="host" like_debuggee '
         self.cmd = f"qemu-system-{self.qemu_arch} -m {self.memory} -smp {self.smp} -kernel {kernel}"
         if self.qemu_arch == "aarch64":
             self.cmd += " -cpu cortex-a72"
@@ -103,3 +111,4 @@ class Debuggee(DockerRunner):
         tmux("selectp -t 1")
         runner = f"{dcmd} {self.cmd}"
         tmux_shell(runner)
+        self._ensure_container_is_up()

--- a/src/kernel_builder.py
+++ b/src/kernel_builder.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
-import re
-import time
 import os
-from pathlib import Path
+import re
 import subprocess as sp
+from pathlib import Path
 
 from loguru import logger
 
@@ -131,15 +130,6 @@ class KernelBuilder(DockerRunner):
             exit(-1)
         return self._run_ssh(f"{self.cc} ARCH={self.arch} {self.llvm_flag} make -j$(nproc) modules")
 
-    def _wait_for_container(self) -> None:
-        logger.info("Waiting for Container to be up...")
-        while True:
-            c = self.cli.inspect_container(self.container.id)
-            if c["State"]["Health"]["Status"] != "healthy":
-                time.sleep(1)
-            else:
-                break
-
     def _add_multiple_mods(self, modules: list[Path]) -> None:
         for d in modules:
             if not d.is_dir():
@@ -188,7 +178,7 @@ class KernelBuilder(DockerRunner):
                 detach=True,
                 tty=True,
             )
-            self._wait_for_container()
+            self.wait_for_container()
             self.init_ssh()
             if self.dirty:
                 self._make_clean()

--- a/src/misc.py
+++ b/src/misc.py
@@ -4,10 +4,10 @@ import configparser
 import hashlib
 import os
 import subprocess as sp
+import termios
 from contextlib import contextmanager
 from pathlib import Path
 from sys import stdin
-import termios
 
 from loguru import logger
 
@@ -59,6 +59,12 @@ def _set_cfg(cfg, obj, sect, key, ignore_empty) -> None:
         return
     val = tmp if tmp not in ["yes", "no"] else cfg[sect].getboolean(key)
     setattr(obj, key, val)
+
+
+def get_value_from_section_by_key(config, section, key) -> str:
+    cfg = configparser.ConfigParser()
+    cfg.read(config)
+    return cfg[section][key]
 
 
 def is_reuse(p: str) -> bool:

--- a/src/tests/test_debuggee.py
+++ b/src/tests/test_debuggee.py
@@ -147,7 +147,8 @@ def test_add_smep_smap() -> None:
 @patch("termios.tcflush", return_value=True)
 @patch("builtins.input", lambda *args: "y")
 @patch.object(Debuggee, "infer_qemu_fs_mount", return_value=" -initrd /foo/bar.cpio")
-def test_run_x86_all_mitigations_kvm_gdb(tmock, tsmock, infer_mock, flush_mock) -> None:
+@patch.object(Debuggee, "_ensure_container_is_up", return_value=0)
+def test_run_x86_all_mitigations_kvm_gdb(tmock, tsmock, flush_mock, infer_mock, up_mock) -> None:
     d = Debuggee(**{"kroot": "foo", "ctf_ctx": False})
     d.kaslr = True
     d.smep = True
@@ -169,7 +170,8 @@ def test_run_x86_all_mitigations_kvm_gdb(tmock, tsmock, infer_mock, flush_mock) 
 @patch("termios.tcflush", return_value=True)
 @patch("builtins.input", lambda *args: "y")
 @patch.object(Debuggee, "infer_qemu_fs_mount", return_value=" -initrd /foo/bar.cpio")
-def test_run_x86_no_mitigations_kvm_gdb(tmock, tsmock, infer_mock, flush_mock) -> None:
+@patch.object(Debuggee, "_ensure_container_is_up", return_value=0)
+def test_run_x86_no_mitigations_kvm_gdb(tmock, tsmock, flush_mock, infer_mock, up_mock) -> None:
     d = Debuggee(**{"kroot": "foo", "ctf_ctx": False})
     d.kaslr = False
     d.smep = False
@@ -192,7 +194,8 @@ def test_run_x86_no_mitigations_kvm_gdb(tmock, tsmock, infer_mock, flush_mock) -
 @patch("termios.tcflush", return_value=True)
 @patch("builtins.input", lambda *args: "y")
 @patch.object(Debuggee, "infer_qemu_fs_mount", return_value=" -initrd /foo/bar.cpio")
-def test_run_arm_no_mitigations_kvm_on(tmock, tsmock, infer_mock, flush_mock) -> None:
+@patch.object(Debuggee, "_ensure_container_is_up", return_value=0)
+def test_run_arm_no_mitigations_kvm_on(tmock, tsmock, flush_mock, infer_mock, up_mock) -> None:
     d = Debuggee(**{"kroot": "foo", "ctf_ctx": False})
     d.kaslr = False
     d.smep = False

--- a/src/tests/test_debugger.py
+++ b/src/tests/test_debugger.py
@@ -1,7 +1,8 @@
-from pathlib import Path
-from src.debugger import GDB_SCRIPT_HIST, Debugger
-from unittest.mock import patch
 import hashlib
+from pathlib import Path
+from unittest.mock import patch
+
+from src.debugger import GDB_SCRIPT_HIST, Debugger
 
 TPATH = Path("/tmp/.hist")
 TPATH_NEW = Path("/tmp/.hist_new")
@@ -87,6 +88,7 @@ def test_run_container(tflush, tsmock, tmock) -> None:
     d = Debugger(**{"kroot": "foo"})
     d.project_dir = "/some/project_dir"
     d.tag = "tag"
+    d.ext = "gef"
     d.run_container()
-    expected = f"send-keys 'docker run -it --rm --security-opt seccomp=unconfined --cap-add=SYS_PTRACE -v {d.project_dir}:{d.docker_mnt} --net=\"host\" {d.tag} /bin/bash -c \"set -e; . /home/user/debugger.sh -a {d.arch} -p /io -c 0 -g /home/user/gdb_script\"' 'C-m'"
+    expected = f"send-keys 'docker run --pid=container:{d.debuggee_name} -it --rm --security-opt seccomp=unconfined --cap-add=SYS_PTRACE -v {d.project_dir}:{d.docker_mnt} --net=\"host\" {d.tag} /bin/bash -c \"set -e; . /home/user/debugger.sh -a {d.arch} -p /io -c 0 -g /home/user/gdb_script -e gef\"' 'C-m'"
     tmock.assert_called_with(expected)

--- a/src/tests/test_docker_runner.py
+++ b/src/tests/test_docker_runner.py
@@ -1,11 +1,13 @@
-from docker.models.containers import Container
-from docker import DockerClient
-from ..docker_runner import DockerRunner
-from pathlib import Path
-from unittest.mock import patch, Mock
-import pytest
-import uuid
 import shutil
+import uuid
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from docker import DockerClient
+from docker.models.containers import Container
+
+from ..docker_runner import DockerRunner
 
 GENERIC_ARGS = {
     "skip_prompts": False,
@@ -91,13 +93,6 @@ def test_stop_container() -> None:
     mdr.stop_container()
     new_len = len(mdr.list_running_containers()) > 0
     assert old_len == new_len
-
-
-def test_wait_for_container() -> None:
-    mdr = MockDockerRunner(**GENERIC_ARGS | MOCK_UNPACKER_RES)
-    mdr.run_container("busybox", "latest", "/bin/true")
-    ret = mdr.wait_for_container()
-    assert ret["StatusCode"] == 0
 
 
 def test_check_existing_ok() -> None:

--- a/src/tests/test_kernel_builder.py
+++ b/src/tests/test_kernel_builder.py
@@ -287,7 +287,7 @@ def get_run_kbuilder(mode: str) -> KernelBuilder:
 @patch.object(KernelBuilder, "_build_kvm_guest", return_value=0)
 @patch.object(KernelBuilder, "_configure_kernel", return_value=0)
 @patch.object(KernelBuilder, "_make", return_value=0)
-@patch.object(KernelBuilder, "_wait_for_container", return_value=0)
+@patch.object(KernelBuilder, "wait_for_container", return_value=0)
 @patch.object(KernelBuilder, "init_ssh", return_value=0)
 @patch.object(KernelBuilder, "_run_ssh", return_value=0)
 @patch("termios.tcflush", return_value=True)
@@ -307,7 +307,7 @@ def test_run_no_config_mode(a, b, c, d, e, f, g, h, j, k, lvname, m):
 @patch.object(KernelBuilder, "_build_kvm_guest", return_value=0)
 @patch.object(KernelBuilder, "_configure_kernel", return_value=0)
 @patch.object(KernelBuilder, "_make", return_value=0)
-@patch.object(KernelBuilder, "_wait_for_container", return_value=0)
+@patch.object(KernelBuilder, "wait_for_container", return_value=0)
 @patch.object(KernelBuilder, "init_ssh", return_value=0)
 @patch.object(KernelBuilder, "_run_ssh", return_value=0)
 @patch("termios.tcflush", return_value=True)
@@ -325,4 +325,4 @@ def test_wait_for_container() -> None:
     kb.container.id = 42
     kb.cli = Mock()
     kb.cli.inspect_container.return_value = {"State": {"Health": {"Status": "healthy"}}}
-    kb._wait_for_container()
+    kb.wait_for_container()

--- a/src/tests/test_misc.py
+++ b/src/tests/test_misc.py
@@ -1,29 +1,32 @@
-from src.misc import (
-    cfg_setter,
-    cross_compile,
-    adjust_toolchain_arch,
-    adjust_arch,
-    adjust_qemu_arch,
-    get_sha256_from_file,
-    is_reuse,
-    new_context,
-    tmux,
-    tmux_shell,
-    _set_cfg,
-    _set_base_cfg,
-    _cherry_pick,
-)
+import configparser
+import subprocess as sp
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
 
 from src.debuggee import Debuggee
 from src.debugger import Debugger
 from src.kernel_builder import KernelBuilder
+from src.misc import (
+    SYSTEM_CFG,
+    _cherry_pick,
+    _set_base_cfg,
+    _set_cfg,
+    adjust_arch,
+    adjust_qemu_arch,
+    adjust_toolchain_arch,
+    cfg_setter,
+    cross_compile,
+    get_sha256_from_file,
+    get_value_from_section_by_key,
+    is_reuse,
+    new_context,
+    tmux,
+    tmux_shell,
+)
 from src.rootfs_builder import RootFSBuilder
-import pytest
-import uuid
-from pathlib import Path
-import configparser
-import subprocess as sp
-from unittest.mock import MagicMock, patch, Mock
 
 MMP_INI = Path("src/tests/confs/lkdl_mmp.ini")
 CFG_INI = Path("src/tests/confs/cfg_setter.ini")
@@ -191,3 +194,7 @@ def test_cfg_setter_debuggee() -> None:
     assert d.rootfs_ftype == "ext4"
     assert d.arch == "arm64"
     assert d.panic == "foo"
+
+
+def test_get_value_from_section_by_key() -> None:
+    assert get_value_from_section_by_key(SYSTEM_CFG, "debuggee_docker", "tag") == "like_debuggee"

--- a/start_kgdb.py
+++ b/start_kgdb.py
@@ -130,7 +130,7 @@ def parse_cli() -> argparse.Namespace:
     Stage 2 - Stage 1 & unpacking,
     Stage 3 - Stage 2 & building,
     Stage 4 - RootFS building only.
-    Stage 5 - Stage 3+4 & Starting the debugee.
+    Stage 5 - Stage 3+4 & Starting the debuggee.
     """
         ),
     )
@@ -139,7 +139,6 @@ def parse_cli() -> argparse.Namespace:
         "-u",
         type=int,
         choices=range(1, 7),
-        default=0,
         help=textwrap.dedent(
             """\
         1 - Update all containers,
@@ -162,7 +161,7 @@ def set_generic_ctx(args, log_level):
         "ctf_ctx": True if args.ctf else False,
         "log_level": log_level,
         "user_cfg": args.config[0] if args.config else "",
-        "update_containers": True if args.update_containers != 0 else False,
+        "update_containers": True if args.update_containers is not None else False,
     }
     return generic_args
 


### PR DESCRIPTION
**NOT MERGABLE YET**

I'm currently running into a 

```
pwndbg: loaded 196 commands. Type pwndbg [filter] for a list.
pwndbg: created $rebase, $ida gdb functions (can be used with print/break)
The target architecture is set to "i386:x86-64:intel".
Reading symbols from /io/vmlinux...
add symbol table from file "/io/vmlinux"
Reading symbols from /io/vmlinux...
Breakpoint 1 at 0xffffffff82cff9b4: file init/main.c, line 849.
The program is not being run.
loading vmlinux
Remote debugging using :1234
0x000000000000fff0 in exception_stacks ()
------- tip of the day (disable with set show-tips off) -------
GDB's follow-fork-mode parameter can be used to set whether to trace parent or child after fork() calls
Exception occurred: Error: invalid literal for int() with base 10: '' (<class 'ValueError'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
Python Exception <class 'ValueError'> invalid literal for int() with base 10: '':
pwndbg> set exception-verbose on
Set whether to print a full stacktrace for exceptions raised in Pwndbg commands to True
Traceback (most recent call last):
  File "/home/user/pwndbg/pwndbg/gdblib/events.py", line 164, in caller
    func()
  File "/home/user/pwndbg/pwndbg/symbol.py", line 96, in autofetch
    for mapping in pwndbg.vmmap.get():
  File "/home/user/pwndbg/pwndbg/lib/memoize.py", line 49, in __call__
    value = self.func(*args, **kwargs)
  File "/home/user/pwndbg/pwndbg/vmmap.py", line 62, in get
    pages.extend(kernel_vmmap_via_page_tables())
  File "/home/user/pwndbg/pwndbg/lib/memoize.py", line 49, in __call__
    value = self.func(*args, **kwargs)
  File "/home/user/pwndbg/pwndbg/vmmap.py", line 358, in kernel_vmmap_via_page_tables
    p.lazy_init()
  File "/home/user/pwndbg/gdb-pt-dump/pt.py", line 162, in lazy_init
    pid = int(proc.read().strip(), 10)
ValueError: invalid literal for int() with base 10: ''

If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues
(Please don't forget to search if it hasn't been reported before)
To generate the report and open a browser, you may run `bugreport --run-browser`
PS: Pull requests are welcome
Traceback (most recent call last):
  File "/home/user/pwndbg/pwndbg/gdblib/prompt.py", line 47, in initial_hook
    prompt_hook(*a)
  File "/home/user/pwndbg/pwndbg/gdblib/prompt.py", line 57, in prompt_hook
    pwndbg.gdblib.events.after_reload(start=cur is None)
  File "/home/user/pwndbg/pwndbg/gdblib/events.py", line 234, in after_reload
    f()
  File "/home/user/pwndbg/pwndbg/gdblib/events.py", line 169, in caller
    raise e
  File "/home/user/pwndbg/pwndbg/gdblib/events.py", line 164, in caller
    func()
  File "/home/user/pwndbg/pwndbg/symbol.py", line 96, in autofetch
    for mapping in pwndbg.vmmap.get():
  File "/home/user/pwndbg/pwndbg/lib/memoize.py", line 49, in __call__
    value = self.func(*args, **kwargs)
  File "/home/user/pwndbg/pwndbg/vmmap.py", line 62, in get
    pages.extend(kernel_vmmap_via_page_tables())
  File "/home/user/pwndbg/pwndbg/lib/memoize.py", line 49, in __call__
    value = self.func(*args, **kwargs)
  File "/home/user/pwndbg/pwndbg/vmmap.py", line 358, in kernel_vmmap_via_page_tables
    p.lazy_init()
  File "/home/user/pwndbg/gdb-pt-dump/pt.py", line 162, in lazy_init
    pid = int(proc.read().strip(), 10)
ValueError: invalid literal for int() with base 10: ''

```