### PR TITLE
Allow creating musl ELF exploits on x86 macOS

### DIFF
--- a/.dockerfile_compiler_mac
+++ b/.dockerfile_compiler_mac
@@ -1,0 +1,26 @@
+FROM like_dbg_base:latest
+LABEL maintainer="Christopher Krah <admin@0x434b.dev>"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ARG USER
+
+WORKDIR /home/$USER
+
+
+RUN apt-get update && \
+    set -e && \
+    apt-get install -yq --no-install-recommends \
+        libc-dev \
+        binutils \
+        musl-tools \
+        libc6-dev && \
+    apt-get -y autoremove --purge && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV LC_ALL=en_US.UTF-8
+
+
+USER $USER
+WORKDIR /io

--- a/ctf/misc/cpio.sh
+++ b/ctf/misc/cpio.sh
@@ -9,7 +9,6 @@ ENC=0
 DEC=0
 EXPLOIT=
 
-
 usage() {
     cat << EOF
 This script is a helper to (un-)pack rootfs.cpio(.gz) root file systems on the fly.
@@ -39,7 +38,7 @@ is_exist() {
 compile_mac() {
     CTR=0
     while true; do
-        if [ $(basename $PWD) != "like-dbg" ] || [ ! -f "$(pwd)/.dockerfile_base" ] ; then
+        if [ $(basename $PWD) != "like-dbg" ] || [ ! -f "$(pwd)/.dockerfile_base" ]; then
             pushd .. > /dev/null
             ((CTR++))
         else


### PR DESCRIPTION
This does not account for M1 macs, but allows building an x86_64 ELF exploit file on an x86 mac.