### PR TITLE
Use ubuntu2204 as a base image

### DIFF
--- a/.dockerfile_base
+++ b/.dockerfile_base
@@ -1,4 +1,3 @@
-#FROM debian:bullseye-slim
 FROM ubuntu:22.04
 LABEL maintainer="Christopher Krah <admin@0x434b.dev>"
 

--- a/.dockerfile_base
+++ b/.dockerfile_base
@@ -1,4 +1,5 @@
-FROM debian:bullseye-slim
+#FROM debian:bullseye-slim
+FROM ubuntu:22.04
 LABEL maintainer="Christopher Krah <admin@0x434b.dev>"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/.dockerfile_kbuilder
+++ b/.dockerfile_kbuilder
@@ -17,7 +17,6 @@ RUN apt-get update && \
         libssl-dev \
         xz-utils \
         ccache \
-        linux-headers-$(uname -r) \
         bc \
         gcc-$TOOLCHAIN_ARCH-linux-gnu \
         binutils-$TOOLCHAIN_ARCH-linux-gnu \

--- a/examples/like_dbg_confs/echo_module.ini
+++ b/examples/like_dbg_confs/echo_module.ini
@@ -3,4 +3,4 @@
 custom_modules = examples/c_kmod/
 
 [kernel_dl]
-tag = 6.0
+tag = 5.15


### PR DESCRIPTION
This is a short-term fix for #112.
Ubuntu 22.04 ships with GLIBC2.35 and should allows us to compile newer kernel versions for now...