### PR TITLE
docs: fix typos in CONTRIBUTING.md and examples/README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ I have adopted a Code of Conduct that I expect project participants to adhere to
 Please [read the full text](https://github.com/0xricksanchez/like-dbg/blob/main/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
 ## Discussions
-If you're curious about a feature, the state of development, want to adapt this project for another use-case, or have anything else on your mind feel free to head over to the [discusions page](https://github.com/0xricksanchez/like-dbg/discussions).
+If you're curious about a feature, the state of development, want to adapt this project for another use-case, or have anything else on your mind feel free to head over to the [discussions page](https://github.com/0xricksanchez/like-dbg/discussions).
 This will be the best place to discuss topics in detail.
 
 ## Developing with Github

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,3 @@
 # README
 
-This directory houses example use cases and demo configutations for LIKE-DBG.
+This directory houses example use cases and demo configurations for LIKE-DBG.


### PR DESCRIPTION
This pull request fixes typo in `CONTRIBUTING.md` and `examples/README.md`. I kindly request the repository maintainers to review and merge it. Thanks! :heart: